### PR TITLE
Spacing consistency around logo

### DIFF
--- a/components/logo-link/styles/_image.scss
+++ b/components/logo-link/styles/_image.scss
@@ -1,6 +1,6 @@
 @mixin base() {
-    height: $component-logo-link-image-height;
     display: block;
+    height: $component-logo-link-image-height;
 }
 
 &__image {

--- a/components/logo-link/styles/_image.scss
+++ b/components/logo-link/styles/_image.scss
@@ -1,5 +1,6 @@
 @mixin base() {
     height: $component-logo-link-image-height;
+    display: block;
 }
 
 &__image {

--- a/components/page-header/styles/_branding.scss
+++ b/components/page-header/styles/_branding.scss
@@ -2,8 +2,8 @@
     flex-basis: auto;
     flex-grow: 0;
     flex-shrink: 0;
-    padding-bottom: space(1);
-    padding-left: space(1);
+    padding-bottom: space(2);
+    padding-left: space(2);
     padding-right: space(1);
     padding-top: space(1);
 


### PR DESCRIPTION
This made the logo image a block to remove 6px height diff and added padding for image placement consistency. Fixes #7.