### PR TITLE
Page header content full width

### DIFF
--- a/components/page-header/readme.md
+++ b/components/page-header/readme.md
@@ -16,14 +16,14 @@ A component for positioning/layout purposes.  **Willow-Page-Header** should only
 
 ```html
 <header class="willow-page-header" role="banner">
-  <div class="willow-page-header__branding"><!-- insert Willow-Logo-Link Component Here --></div>
-  <div class="willow-page-header__content-controls">
-      <a href="" class="willow-page-header__content-open">menu</a>
-      <a href="" class="willow-page-header__content-close">close</a>
-  </div>
-  <div class="willow-page-header__content">
-      <div class="willow-page-header__navigation"><!-- insert Willow-Primary-Nav Component Here --></div>
-  </div>
+    <div class="willow-page-header__branding"><!-- insert Willow-Logo-Link Component Here --></div>
+    <div class="willow-page-header__content-controls">
+        <a class="willow-page-header__content-open" aria-label="Open Menu" href="">menu</a>
+        <a class="willow-page-header__content-close" aria-label="Close Menu"href="">close</a>
+    </div>
+    <div class="willow-page-header__content">
+        <div class="willow-page-header__navigation"><!-- insert Willow-Primary-Nav Component Here --></div>
+    </div>
 </header>
 ```
 
@@ -74,6 +74,8 @@ A component for positioning/layout purposes.  **Willow-Page-Header** should only
 #### _Notes_
 
 - clicking **willow-page-header__content-open** should set **willow-page-header** `data-content-open` state attribute to `true`
+- **willow-page-header__content-open** needs an `aria-label` attribute to define what the link does
+  - This is required for low or no sight users or if the key word "Menu" is removed from the link
 
 ---
 
@@ -86,6 +88,8 @@ A component for positioning/layout purposes.  **Willow-Page-Header** should only
 #### _Notes_
 
 - clicking **willow-page-header__content-close** should set **willow-page-header** `data-content-open` state attribute to `false`
+- **willow-page-header__content-close** needs an `aria-label` attribute to define what the link does
+  - This is required for low or no sight users or if the key word "Close" is removed from the link
 
 ---
 

--- a/components/page-header/snippets/index.html
+++ b/components/page-header/snippets/index.html
@@ -1,8 +1,8 @@
 <header class="willow-page-header" role="banner">
     <div class="willow-page-header__branding"><!-- insert Willow-Logo-Link Component Here --></div>
     <div class="willow-page-header__content-controls">
-        <a href="" class="willow-page-header__content-open">menu</a>
-        <a href="" class="willow-page-header__content-close">close</a>
+        <a class="willow-page-header__content-open" aria-label="Open Menu" href="">menu</a>
+        <a class="willow-page-header__content-close" aria-label="Close Menu"href="">close</a>
     </div>
     <div class="willow-page-header__content">
         <div class="willow-page-header__navigation"><!-- insert Willow-Primary-Nav Component Here --></div>

--- a/components/page-header/styles/_content-controls.scss
+++ b/components/page-header/styles/_content-controls.scss
@@ -4,7 +4,7 @@
     justify-content: flex-end;
     padding-bottom: space(1);
     padding-left: space(1);
-    padding-right: space(2);
+    padding-right: 0;
     padding-top: space(2);
 
     @media screen and (min-width: breakpoint(medium)) {

--- a/components/page-header/styles/_content.scss
+++ b/components/page-header/styles/_content.scss
@@ -1,8 +1,10 @@
 @mixin base() {
     @include set-text-style($text-style-content-1);
+    @include full-width;
+
     border-top: 2px solid $component-page-header-navigation-border-color;
     display: none;
-    flex-basis: 100%;
+    flex-basis: 100vw;
     flex-grow: 0;
     flex-shrink: 1;
 
@@ -18,6 +20,10 @@
         border-top: none;        
         display: block;
         flex-basis: auto;
+        margin-bottom: 0;
+        margin-left: 0;
+        margin-top: 0;
+        margin-right: 0;
 
         [data-content-open="false"] & {
             display: block;


### PR DESCRIPTION
page-header__content wasn't filling space on mobile needed the full-bleed mixin and some margin tweaking to prevent full-bleed from effecting desktop.