### PR TITLE
Icon bugfix

### DIFF
--- a/global/variables/constants/maps/_icons.scss
+++ b/global/variables/constants/maps/_icons.scss
@@ -1,5 +1,5 @@
 // @import "../../../utilities/mixins/icon";
-$icons-folder: "../node_modules/@unumux/willow/globla/icons" !default;
+$icons-folder: "../node_modules/@unumux/willow/global/icons" !default;
 
 $icon-menu: (
     icon: url("#{$icons-folder}/menu.svg"),

--- a/global/variables/constants/maps/_icons.scss
+++ b/global/variables/constants/maps/_icons.scss
@@ -1,5 +1,5 @@
 // @import "../../../utilities/mixins/icon";
-$icons-folder: "../node_modules/@unumux/willow/icons" !default;
+$icons-folder: "../node_modules/@unumux/willow/globla/icons" !default;
 
 $icon-menu: (
     icon: url("#{$icons-folder}/menu.svg"),


### PR DESCRIPTION
The most recent update of Willow changed the folder structure and this path didn't get updated then.  It wasn't discovered in testing b/c we had the icon-folder set in the project and didn't ever try removing that and only importing Willow.